### PR TITLE
[버그] 보스 분배금 로직이 잘못되었던 문제 수정

### DIFF
--- a/src/app/calculator/partyProfit/_components/AllocationStatusBanner.tsx
+++ b/src/app/calculator/partyProfit/_components/AllocationStatusBanner.tsx
@@ -1,11 +1,9 @@
-import { formatKoreanNumber } from '@/utils/numberUtils'
 import { BiErrorCircle } from 'react-icons/bi'
 
 interface Props {
   isVisible: boolean
   overRatio: number
   remainingRatio: number
-  remainder: number
 }
 
 const BannerLayout = ({ children }: { children: React.ReactNode }) => {
@@ -21,7 +19,6 @@ const AllocationStatusBanner = ({
   isVisible,
   overRatio,
   remainingRatio,
-  remainder,
 }: Props) => {
   if (!isVisible) {
     return <div className="w-full bg-gray-300 dark:bg-neutral-700 my-4" />
@@ -41,7 +38,6 @@ const AllocationStatusBanner = ({
     <BannerLayout>
       <div className="flex gap-3">
         <span>남은 비율 : {remainingRatio}</span>
-        <span>남은 메소 : {formatKoreanNumber(remainder)}</span>
       </div>
     </BannerLayout>
   )

--- a/src/app/calculator/partyProfit/_components/PartyMemberCard.tsx
+++ b/src/app/calculator/partyProfit/_components/PartyMemberCard.tsx
@@ -42,9 +42,16 @@ const PartyMemberCard = ({
           </div>
         </div>
         <div className="text-[13px] text-gray-600 dark:text-gray-300">
+          송금할 금액:{' '}
+          <span className="text-[16px] font-semibold text-blue-700 dark:text-blue-400">
+            {formatKoreanNumber(member.transferAmount)}
+          </span>{' '}
+          메소
+        </div>
+        <div className="text-[13px] text-gray-600 dark:text-gray-300">
           최종 분배금:{' '}
           <span className="text-[16px] font-semibold text-blue-700 dark:text-blue-400">
-            {formatKoreanNumber(member.amount)}
+            {formatKoreanNumber(member.finalReceivedAmount)}
           </span>{' '}
           메소
         </div>

--- a/src/app/calculator/partyProfit/_components/PartyMemberControl.tsx
+++ b/src/app/calculator/partyProfit/_components/PartyMemberControl.tsx
@@ -12,7 +12,6 @@ const PartyMemberControl = ({ netAmount, feeRate }: Props) => {
   const {
     mode,
     members,
-    remainder,
     overRatio,
     remainingRatio,
     canAddMember,
@@ -51,7 +50,6 @@ const PartyMemberControl = ({ netAmount, feeRate }: Props) => {
           isVisible={isAllocationBannerVisible}
           overRatio={overRatio}
           remainingRatio={remainingRatio}
-          remainder={remainder}
         />
         <PartyMemberList
           members={members}

--- a/src/app/calculator/partyProfit/_hooks/usePartyDistribution.ts
+++ b/src/app/calculator/partyProfit/_hooks/usePartyDistribution.ts
@@ -129,8 +129,7 @@ export const usePartyDistribution = (totalProfit: number, feeRate: number) => {
   return {
     mode: state.mode,
 
-    members: distribution.results,
-    remainder: distribution.remainder,
+    members: distribution,
 
     canAddMember: canAddMember,
     remainingRatio: remainingRatio,

--- a/src/app/calculator/partyProfit/_utils/distributeProfitByPercent.ts
+++ b/src/app/calculator/partyProfit/_utils/distributeProfitByPercent.ts
@@ -71,14 +71,12 @@ export const distributeProfitByPercent = (
   const activeOwnerIndex = 0
   const ownerMember = normalizedMembers[activeOwnerIndex]
 
-  // 3. 핵심 지표 계산 (Fair Base Profit)
   const fairBaseProfit = calculateFairBaseProfit(
     totalProfit,
     ownerMember.ratio,
     feeRate,
   )
 
-  // 4. 개별 결과 계산 (매핑)
   const results = normalizedMembers.map((member, idx) =>
     computeMemberShare(
       member,

--- a/src/app/calculator/partyProfit/_utils/distributeProfitByPercent.ts
+++ b/src/app/calculator/partyProfit/_utils/distributeProfitByPercent.ts
@@ -2,33 +2,91 @@ export type DistributionResult = {
   id: string
   name: string
   ratio: number
-  amount: number
+  transferAmount: number // 입력 금액 (송금액)
+  finalReceivedAmount: number // 실수령액
 }
 
 type Member = { id: string; name: string; ratio: number }
 type Mode = 'MANUAL' | 'EQUAL'
+
+const normalizeMembers = (members: Member[], mode: Mode): Member[] => {
+  if (mode === 'EQUAL') {
+    const equalRatio = 100 / members.length
+    return members.map((m) => ({ ...m, ratio: equalRatio }))
+  }
+  return members
+}
+
+const calculateFairBaseProfit = (
+  totalProfit: number,
+  ownerRatio: number,
+  feeRate: number,
+): number => {
+  const r = feeRate / 100
+  const wOwner = ownerRatio / 100
+
+  const denominator = wOwner + (1 - wOwner) / (1 - r)
+
+  if (denominator <= 0) return 0
+  return totalProfit / denominator
+}
+
+const computeMemberShare = (
+  member: Member,
+  fairBaseProfit: number,
+  feeRate: number,
+  isOwner: boolean,
+): DistributionResult => {
+  const r = feeRate / 100
+  const w = member.ratio / 100
+
+  const targetFinal = Math.floor(fairBaseProfit * w)
+
+  if (isOwner) {
+    return {
+      ...member,
+      transferAmount: 0,
+      finalReceivedAmount: targetFinal,
+    }
+  }
+
+  const transfer = Math.floor(targetFinal / (1 - r))
+  const finalReceived = Math.floor(transfer * (1 - r))
+
+  return {
+    ...member,
+    transferAmount: transfer,
+    finalReceivedAmount: finalReceived,
+  }
+}
 
 export const distributeProfitByPercent = (
   totalProfit: number,
   feeRate: number,
   members: Member[],
   mode: Mode,
-) => {
-  const memberCount = members.length
+): DistributionResult[] => {
+  const normalizedMembers = normalizeMembers(members, mode)
 
-  const fee = memberCount >= 2 ? Math.floor((totalProfit * feeRate) / 100) : 0
-  const distributable = totalProfit - fee
+  const activeOwnerIndex = 0
+  const ownerMember = normalizedMembers[activeOwnerIndex]
 
-  const results: DistributionResult[] = members.map((m) => ({
-    ...m,
-    amount:
-      mode === 'MANUAL'
-        ? Math.floor((distributable * m.ratio) / 100)
-        : Math.floor(distributable / memberCount),
-  }))
+  // 3. 핵심 지표 계산 (Fair Base Profit)
+  const fairBaseProfit = calculateFairBaseProfit(
+    totalProfit,
+    ownerMember.ratio,
+    feeRate,
+  )
 
-  const distributed = results.reduce((sum, r) => sum + r.amount, 0)
-  const remainder = distributable - distributed
+  // 4. 개별 결과 계산 (매핑)
+  const results = normalizedMembers.map((member, idx) =>
+    computeMemberShare(
+      member,
+      fairBaseProfit,
+      feeRate,
+      idx === activeOwnerIndex, // isOwner check
+    ),
+  )
 
-  return { results, remainder }
+  return results
 }


### PR DESCRIPTION
## 개요
- #85 

경매장 판매 후 실수령액 기준으로 분배하는 과정에서 팀원 송금 시 발생하는 수수료를 고려하지 않아
분배 비율을 수동으로 변경할 경우 계산 결과가 잘못되는 문제를 수정하고 송금해야 하는 금액을 추가함

### 구조 변경
**normalizeMembers**
- 분배 모드에 따라 멤버들의 비율을 정규화하는 함수

**calculateFairBaseProfit**
- 경매장 실수령액과 송금 수수료를 고려해 모든 멤버가 비율대로 최종 수령액을 갖게 되도록 하는 기준 금액을 계산

**computeMemberShare**
- 멤버 한 명에 대한 분배 결과를 계산
- 팀원은 송금 수수료를 고려해 필요한 송금액을 역산